### PR TITLE
Add build time fonts sync for android

### DIFF
--- a/react.gradle
+++ b/react.gradle
@@ -14,7 +14,7 @@ def bundleCommand = config.bundleCommand ?: "bundle"
 def reactRoot = file(config.root ?: "../../")
 def inputExcludes = config.inputExcludes ?: ["android/**", "ios/**"]
 def bundleConfig = config.bundleConfig ? "${reactRoot}/${config.bundleConfig}" : null ;
-def fontsDir = file(config.fontsDir ?: "${reactRoot}/js/assets/fonts")
+def fontsDir = file(config.fontsDir ?: "${reactRoot}/assets/fonts")
 
 
 afterEvaluate {

--- a/react.gradle
+++ b/react.gradle
@@ -14,6 +14,7 @@ def bundleCommand = config.bundleCommand ?: "bundle"
 def reactRoot = file(config.root ?: "../../")
 def inputExcludes = config.inputExcludes ?: ["android/**", "ios/**"]
 def bundleConfig = config.bundleConfig ? "${reactRoot}/${config.bundleConfig}" : null ;
+def fontsDir = file(config.fontsDir ?: "${reactRoot}/js/assets/fonts")
 
 
 afterEvaluate {
@@ -159,6 +160,29 @@ afterEvaluate {
         packageTask.dependsOn(currentAssetsCopyTask)
         if (buildPreBundleTask != null) {
             buildPreBundleTask.dependsOn(currentAssetsCopyTask)
+        }
+        
+        def currentFontsCopyTask = tasks.create(
+                name: "copy${targetName}Fonts",
+                type: Copy) {
+            group = "react"
+            description = "Copy fonts into ${targetName}."
+
+            enabled(fontsDir.exists() && fontsDir.isDirectory())
+
+            from (fontsDir)
+            into ("$buildDir/intermediates/assets/fonts")
+
+            // Workaround for Android Gradle Plugin 3.2+ new asset directory
+            into("$buildDir/intermediates/merged_assets/${variant.name}/merge${targetName}Assets/out/fonts")
+
+            // mergeAssets must run first, as it clears the intermediates directory
+            dependsOn(variant.mergeAssetsProvider.get())
+        }
+
+        packageTask.dependsOn(currentFontsCopyTask)
+        if (buildPreBundleTask != null) {
+            buildPreBundleTask.dependsOn(currentFontsCopyTask)
         }
     }
 }


### PR DESCRIPTION
## Summary

https://github.com/react-native-community/discussions-and-proposals/issues/89

## Changelog

[Android] [Changed] - added fonts linking in build time. 

## Test Plan

1) add some fonts in `./assets/fonts`
2) build android apk `./gradlew assembleDebug`
3) find fonts in apk content(you can unzip it or use android studio apk previewer)
![image](https://user-images.githubusercontent.com/13404754/54219111-e3c1f800-44ff-11e9-857c-7d50cd711a9d.png)

